### PR TITLE
Add Dockerfile and entrypoint

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,68 @@
+FROM ubuntu:trusty
+
+RUN sh -c "echo deb http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse >> /etc/apt/sources.list"
+RUN sh -c "echo deb-src http://archive.ubuntu.com/ubuntu trusty-backports main restricted universe multiverse >> /etc/apt/sources.list"
+
+RUN apt-get update && apt-get install -y -q \
+   git \
+   make \
+   openssh-server \
+   openjdk-7-jdk \
+   python-pip \
+   wget \
+   zip \
+   && apt-get clean \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN apt-get update && apt-get install -y -q \
+   connect-proxy \
+   g++ \
+   libcrypto++-dev \
+   libjson0 \
+   libjson0-dev \
+   python-all-dev \
+   python-dev \
+   python-enum \
+   python-setuptools \
+   python-stdeb \
+   python-twisted \
+   python-twisted-web \
+   swig3.0 \
+   && apt-get clean \
+   && rm -rf /var/lib/apt/lists/*
+
+RUN pip install sphinx && \
+   pip install sphinxcontrib-httpdomain && \
+   pip install nose2 && \
+   pip install coverage && \
+   pip install cov-core && \
+   pip install pep8 && \
+   pip install pylint && \
+   pip install setuptools-lint && \
+   pip install sphinx_rtd_theme
+
+RUN ln -s /usr/bin/swig3.0 /usr/bin/swig
+
+RUN pip install https://pypi.python.org/packages/source/c/cbor/cbor-0.1.24.tar.gz
+RUN pip install https://pypi.python.org/packages/2.7/c/colorlog/colorlog-2.6.0-py2.py3-none-any.whl
+RUN pip install https://pypi.python.org/packages/source/p/pybitcointools/pybitcointools-1.1.15.tar.gz
+
+ENV PYTHONPATH=/project/sawtooth-core:/project/sawtooth-validator:/project/sawtooth-mktplace:/project/sawtooth-core/build/lib.linux-x86_64-2.7
+
+COPY ./sawtooth-core /project/sawtooth-core
+COPY ./sawtooth-validator /project/sawtooth-validator
+COPY ./sawtooth-mktplace /project/sawtooth-mktplace
+COPY ./sawtooth-docs /project/sawtooth-docs
+
+WORKDIR /project/sawtooth-core
+RUN python setup.py build
+
+COPY ./sawtooth-validator /project/sawtooth-validator
+WORKDIR /project/sawtooth-validator
+
+RUN mkdir -p /var/log/sawtooth-validator
+RUN mkdir -p /var/lib/sawtooth-validator
+
+COPY ./sawtooth-dev-tools/entrypoint.sh /project/sawtooth-validator
+ENTRYPOINT ["./entrypoint.sh"]
+

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+set -e
+
+if [ "$#" == 0 ]; then
+    exec ./bin/txnvalidator -v --http 8800 --config /project/sawtooth-docs/source/tutorial/txnvalidator.js "$@"
+fi
+
+exec "$@"


### PR DESCRIPTION
This allows building a docker image suitable for development

## Instructions

To build the image, cd to the `project` location as [suggested by the tutorial](http://intelledger.github.io/tutorial.html#clone-repositories).

```
docker build -t sawtooth-dev -f ./sawtooth-dev-tools/Dockerfile .
```

You can then run it using:
```
docker run sawtooth-dev # will run txnvalidator
docker run -it sawtooth-dev bash # will give you a bash terminal
```

In order to use it for development, you can mount your local volumes like such:

```
docker run -it --rm -v $PWD/sawtooth-core:/project/sawtooth-core sawtooth-dev bash
```

## Discussion

Everything here is up to discussion. From the file locations and names, up to the dependencies.
Expecting a lot of input!